### PR TITLE
Script to generate session thumbnails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ static/*.map
 # Ignore "Gemfile.lock" for Docker Compose
 Gemfile.lock
 .vscode
+speakers.json
+talks.json
+tweets.csv

--- a/_config.yml
+++ b/_config.yml
@@ -56,13 +56,13 @@ collections: # process the _data folder
   components:
     output: false
   schedule:
-    output: true
+    output: false
     permalink: /:collection/:name/
   organisers:
     output: false
     permalink: /:collection/
   presenters:
-    output: true
+    output: false
     permalink: /:collection/
   sponsors:
     output: false
@@ -81,6 +81,9 @@ collections: # process the _data folder
     permalink: /:collection/
   news:
     output: false
+    permalink: /:collection/
+  sessions:
+    output: true
     permalink: /:collection/
 
 # SEO Plugin settings

--- a/_layouts/session-speaker-template.html
+++ b/_layouts/session-speaker-template.html
@@ -1,0 +1,35 @@
+<!doctype html>
+<html class="no-js" lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link href="https://fonts.googleapis.com/css?family=Karla:400,400i,700|Rubik:400,500&amp;display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/static/main.css">
+  </head>
+  <body class="{{ page.layout }}-page">
+
+    <div class="speaker-template">
+      {% if page.photo_url != blank %}
+        <img
+          src="{{ page.photo_url }}"
+          width="520"
+          alt="{{ page.name }}"
+          class="speaker-template-photo" />
+      {% endif %}
+
+      <h1 class="speaker-template-name">
+        {% for speaker in page.speakers %}
+        {% assign speaker_length = page.speakers|size %}
+        {{ speaker }}
+          {% if speaker_length > 1 %}<br>{% endif %}
+        {% endfor %}
+      </h1>
+
+      <h2 class="speaker-template-session-title">
+        {{ page.session_title }}
+      </h2>
+
+    </div>
+
+  </body>
+</html>

--- a/_sessions/a-beginners-guide-to-security-exploits-in-action.md
+++ b/_sessions/a-beginners-guide-to-security-exploits-in-action.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Ashley Mathew
+permalink: /sessions/a-beginners-guide-to-security-exploits-in-action/
+session_type: Talk
+session_title: "A Beginners Guide to Security Exploits in Action"
+photo_url: https://pretalx.com/media/avatars/T0KSHEMUJ-UACJT8GJ3-73260918a579-512_ds0j1Ue.jpeg
+twitter: null
+website: null
+---
+

--- a/_sessions/all-about-djangoproject-com.md
+++ b/_sessions/all-about-djangoproject-com.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Paolo Melchiorre
+permalink: /sessions/all-about-djangoproject-com/
+session_type: Talk
+session_title: "All about djangoproject.com"
+photo_url: https://pretalx.com/media/avatars/52487760478_283a36a901_o-min_JhQ67nS.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/an-evolving-world-of-iot-with-django.md
+++ b/_sessions/an-evolving-world-of-iot-with-django.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Olaniyan Adewale Hafeez
+permalink: /sessions/an-evolving-world-of-iot-with-django/
+session_type: Workshop
+session_title: "An Evolving World of IoT with Django"
+photo_url: https://pretalx.com/media/avatars/photograpghy_LdN33Rx.jpeg
+twitter: null
+website: null
+---
+

--- a/_sessions/best-of-both-worlds-next-js-wagtail.md
+++ b/_sessions/best-of-both-worlds-next-js-wagtail.md
@@ -1,0 +1,14 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Thibaud Colas
+  - Sage Abdullah
+permalink: /sessions/best-of-both-worlds-next-js-wagtail/
+session_type: Workshop
+session_title: "Best of both worlds: Next.js ❤️ Wagtail"
+photo_url: https://www.gravatar.com/avatar/634a765b36b969d27c5ac67c09c41c13
+twitter: null
+website: null
+---
+

--- a/_sessions/beyond-faceted-search.md
+++ b/_sessions/beyond-faceted-search.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Alex Henman
+permalink: /sessions/beyond-faceted-search/
+session_type: Talk
+session_title: "Beyond faceted search"
+photo_url: https://www.gravatar.com/avatar/750750a74bce18e3bf0831510b458049
+twitter: null
+website: null
+---
+

--- a/_sessions/building-and-scaling-a-live-event-platform-with-django-channels.md
+++ b/_sessions/building-and-scaling-a-live-event-platform-with-django-channels.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Raphael Michel
+permalink: /sessions/building-and-scaling-a-live-event-platform-with-django-channels/
+session_type: Talk
+session_title: "Building and scaling a live event platform with django-channels"
+photo_url: https://pretalx.com/media/avatars/photo-2109-square-lachend_Y43Svgg.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/caching-everywhere.md
+++ b/_sessions/caching-everywhere.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Iuri de Silvio
+permalink: /sessions/caching-everywhere/
+session_type: Talk
+session_title: "Caching everywhere"
+photo_url: https://pretalx.com/media/avatars/0261419fbc582731157786f76d1b76b0_1_U2EIitj.jpeg
+twitter: null
+website: null
+---
+

--- a/_sessions/django-accessibility-for-everyone.md
+++ b/_sessions/django-accessibility-for-everyone.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Lauren Parsons
+permalink: /sessions/django-accessibility-for-everyone/
+session_type: Talk
+session_title: "Django Accessibility for Everyone"
+photo_url: https://pretalx.com/media/avatars/signal-2022-09-11-13-34-07-389_Z4IS1vy.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/django-for-analytical-workloads-getting-started-with-snowflake.md
+++ b/_sessions/django-for-analytical-workloads-getting-started-with-snowflake.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Felipe Hoffa
+permalink: /sessions/django-for-analytical-workloads-getting-started-with-snowflake/
+session_type: Workshop
+session_title: "Django for Analytical Workloads: Getting started with Snowflake"
+photo_url: https://www.gravatar.com/avatar/4cfd811c2c01646a1e4f33fb9e68ab5c
+twitter: null
+website: null
+---
+

--- a/_sessions/django-for-life-sciences.md
+++ b/_sessions/django-for-life-sciences.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Nicolas Noé
+permalink: /sessions/django-for-life-sciences/
+session_type: Talk
+session_title: "Django for life (sciences)"
+photo_url: https://pretalx.com/media/avatars/K1WUSiV7_400x400_RXwutnk.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/djangogirls-it-takes-a-village.md
+++ b/_sessions/djangogirls-it-takes-a-village.md
@@ -1,0 +1,13 @@
+---
+hidden: true
+layout: session-speaker-template
+speakers: 
+  - Aisha Bello
+permalink: /sessions/djangogirls-it-takes-a-village/
+session_type: Keynote
+session_title: "DjangoGirls: It takes a Village"
+photo_url: https://pretalx.com/media/avatars/MAS_7978copy_Q0hU0i5.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/do-the-holes-in-swiss-cheese-leak-abstractions.md
+++ b/_sessions/do-the-holes-in-swiss-cheese-leak-abstractions.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Tim Bell
+permalink: /sessions/do-the-holes-in-swiss-cheese-leak-abstractions/
+session_type: Talk
+session_title: "Do the holes in Swiss cheese leak abstractions?"
+photo_url: None
+twitter: null
+website: null
+---
+

--- a/_sessions/efficient-peer-code-review.md
+++ b/_sessions/efficient-peer-code-review.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Luben Alexandrov
+permalink: /sessions/efficient-peer-code-review/
+session_type: Workshop
+session_title: "Efficient Peer Code Review"
+photo_url: https://pretalx.com/media/avatars/Luben_Alexandrov_N1RBhvz.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/gender-bias-in-tech-examining-evolution-persistence-of-stereotypes.md
+++ b/_sessions/gender-bias-in-tech-examining-evolution-persistence-of-stereotypes.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Ester Beltrami
+permalink: /sessions/gender-bias-in-tech-examining-evolution-persistence-of-stereotypes/
+session_type: Talk
+session_title: "Gender Bias in Tech: Examining Evolution & Persistence of Stereotypes"
+photo_url: https://pretalx.com/media/avatars/foto.profilo.1_7fDB5qi.png
+twitter: null
+website: null
+---
+

--- a/_sessions/good-form-how-django-s-form-rendering-improved-during-the-4-x-series.md
+++ b/_sessions/good-form-how-django-s-form-rendering-improved-during-the-4-x-series.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - David Smith
+permalink: /sessions/good-form-how-django-s-form-rendering-improved-during-the-4-x-series/
+session_type: Talk
+session_title: "Good form: How Django’s form rendering improved during the 4.x series"
+photo_url: https://pretalx.com/media/avatars/39445562_qS1Le00.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/green-coding-with-django.md
+++ b/_sessions/green-coding-with-django.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Andrew Aikman
+permalink: /sessions/green-coding-with-django/
+session_type: Talk
+session_title: "Green Coding with django"
+photo_url: None
+twitter: null
+website: null
+---
+

--- a/_sessions/htmx-vs-wasm-more-backend-or-more-frontend.md
+++ b/_sessions/htmx-vs-wasm-more-backend-or-more-frontend.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Cheuk Ting Ho
+permalink: /sessions/htmx-vs-wasm-more-backend-or-more-frontend/
+session_type: Talk
+session_title: "HTMX vs WASM - more backend or more frontend?"
+photo_url: https://pretalx.com/media/avatars/IMG_1037_vjqZpqv.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/just-one-thing-after-n-other.md
+++ b/_sessions/just-one-thing-after-n-other.md
@@ -1,0 +1,13 @@
+---
+hidden: true
+layout: session-speaker-template
+speakers: 
+  - Tobias Kunze
+permalink: /sessions/just-one-thing-after-n-other/
+session_type: Keynote
+session_title: "Just One Thing After n-other"
+photo_url: https://pretalx.com/media/avatars/2021-square_GLwYnAc.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/keynote-djangogirls-it-takes-a-village.md
+++ b/_sessions/keynote-djangogirls-it-takes-a-village.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Aisha Bello
+permalink: /sessions/keynote-djangogirls-it-takes-a-village/
+session_type: Keynote
+session_title: "DjangoGirls: It takes a Village"
+photo_url: https://pretalx.com/media/avatars/MAS_7978copy_Q0hU0i5.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/keynote-just-one-thing-after-n-other.md
+++ b/_sessions/keynote-just-one-thing-after-n-other.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Tobias Kunze
+permalink: /sessions/keynote-just-one-thing-after-n-other/
+session_type: Keynote
+session_title: "Just One Thing After n-other"
+photo_url: https://pretalx.com/media/avatars/2021-square_GLwYnAc.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/let-s-build-a-beeware-app-that-uses-django.md
+++ b/_sessions/let-s-build-a-beeware-app-that-uses-django.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Cheuk Ting Ho
+permalink: /sessions/let-s-build-a-beeware-app-that-uses-django/
+session_type: Workshop
+session_title: "Let's build a BeeWare app that uses Django"
+photo_url: https://pretalx.com/media/avatars/IMG_1037_vjqZpqv.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/mastering-the-django-orm-with-postgresql.md
+++ b/_sessions/mastering-the-django-orm-with-postgresql.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Laurent Tramoy
+permalink: /sessions/mastering-the-django-orm-with-postgresql/
+session_type: Workshop
+session_title: "Mastering the Django ORM with PostgreSQL"
+photo_url: None
+twitter: null
+website: null
+---
+

--- a/_sessions/model-view-controller-mvc-through-the-ages-and-in-django.md
+++ b/_sessions/model-view-controller-mvc-through-the-ages-and-in-django.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Nik Haldimann
+permalink: /sessions/model-view-controller-mvc-through-the-ages-and-in-django/
+session_type: Talk
+session_title: "Model-View-Controller (MVC) through the ages and in Django"
+photo_url: https://pretalx.com/media/avatars/London_2020_2_1_fGTU5to.png
+twitter: null
+website: null
+---
+

--- a/_sessions/practical-tools-for-documentation-at-scale.md
+++ b/_sessions/practical-tools-for-documentation-at-scale.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Daniele Procida
+permalink: /sessions/practical-tools-for-documentation-at-scale/
+session_type: Workshop
+session_title: "Practical tools for documentation at scale"
+photo_url: https://pretalx.com/media/avatars/Daniele_300x400_KvFfbse.JPG
+twitter: null
+website: null
+---
+

--- a/_sessions/squeezing-django-performance-for-14-9-million-users-on-whatsapp.md
+++ b/_sessions/squeezing-django-performance-for-14-9-million-users-on-whatsapp.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Rudi Giesler
+permalink: /sessions/squeezing-django-performance-for-14-9-million-users-on-whatsapp/
+session_type: Talk
+session_title: "Squeezing Django performance for 14.9 million users on WhatsApp"
+photo_url: https://pretalx.com/media/avatars/unnamed_qXjoO15.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/tdd-applied-to-django-api-development.md
+++ b/_sessions/tdd-applied-to-django-api-development.md
@@ -1,0 +1,14 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Vladyslav Lyeuta
+  - Luis Laguna
+permalink: /sessions/tdd-applied-to-django-api-development/
+session_type: Workshop
+session_title: "TDD applied to Django API development"
+photo_url: https://pretalx.com/media/avatars/vlad_76MD1NX.png
+twitter: null
+website: null
+---
+

--- a/_sessions/teaching-children-python-what-works.md
+++ b/_sessions/teaching-children-python-what-works.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Mykalin Jones
+permalink: /sessions/teaching-children-python-what-works/
+session_type: Talk
+session_title: "Teaching Children Python-What Works?"
+photo_url: https://pretalx.com/media/avatars/My_project-14_InauHaY.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/team-building-in-the-django-community-strategies-for-collaboration.md
+++ b/_sessions/team-building-in-the-django-community-strategies-for-collaboration.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Psalms Kalu
+permalink: /sessions/team-building-in-the-django-community-strategies-for-collaboration/
+session_type: Talk
+session_title: "Team Building in the Django Community: Strategies for Collaboration"
+photo_url: https://pretalx.com/media/avatars/DSC_8849_Tcul8oP.png
+twitter: null
+website: null
+---
+

--- a/_sessions/the-evolution-of-a-website-into-a-radio-automation-back-end.md
+++ b/_sessions/the-evolution-of-a-website-into-a-radio-automation-back-end.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Ernesto Rico Schmidt
+permalink: /sessions/the-evolution-of-a-website-into-a-radio-automation-back-end/
+session_type: Talk
+session_title: "The evolution of a Website into a radio automation back-end."
+photo_url: https://pretalx.com/media/avatars/csc_0771_300_4zqRYCT.png
+twitter: null
+website: null
+---
+

--- a/_sessions/the-inevitable-tech-incident-the-lessons-we-just-can-t-seem-to-learn.md
+++ b/_sessions/the-inevitable-tech-incident-the-lessons-we-just-can-t-seem-to-learn.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Ahter Sönmez
+permalink: /sessions/the-inevitable-tech-incident-the-lessons-we-just-can-t-seem-to-learn/
+session_type: Talk
+session_title: "The Inevitable Tech Incident: The Lessons We Just Can't Seem to Learn"
+photo_url: https://pretalx.com/media/avatars/ahter_6YVRtdm.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/the-programmer-s-imagination.md
+++ b/_sessions/the-programmer-s-imagination.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Daniele Procida
+permalink: /sessions/the-programmer-s-imagination/
+session_type: Talk
+session_title: "The programmer's imagination"
+photo_url: https://pretalx.com/media/avatars/Daniele_300x400_KvFfbse.JPG
+twitter: null
+website: null
+---
+

--- a/_sessions/tuning-postgresql-to-work-even-better.md
+++ b/_sessions/tuning-postgresql-to-work-even-better.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Karen Jex
+permalink: /sessions/tuning-postgresql-to-work-even-better/
+session_type: Talk
+session_title: "Tuning PostgreSQL to work even better"
+photo_url: None
+twitter: null
+website: null
+---
+

--- a/_sessions/turning-test-writing-into-a-consistently-brief-and-pleasant-experience.md
+++ b/_sessions/turning-test-writing-into-a-consistently-brief-and-pleasant-experience.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Wilhelm Klopp
+permalink: /sessions/turning-test-writing-into-a-consistently-brief-and-pleasant-experience/
+session_type: Talk
+session_title: "Turning test writing into a consistently brief and pleasant experience"
+photo_url: https://pretalx.com/media/avatars/final-medium_BtP2IN9.png
+twitter: null
+website: null
+---
+

--- a/_sessions/use-sqlite-in-production.md
+++ b/_sessions/use-sqlite-in-production.md
@@ -1,0 +1,13 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Tom Dyson
+permalink: /sessions/use-sqlite-in-production/
+session_type: Talk
+session_title: "Use SQLite in production"
+photo_url: https://pretalx.com/media/avatars/tom-wagtail-space-talk-2022-smaller_zIbElWe.jpg
+twitter: null
+website: null
+---
+

--- a/_sessions/you-ve-got-trust-issues-we-ve-got-solutions-differential-privacy.md
+++ b/_sessions/you-ve-got-trust-issues-we-ve-got-solutions-differential-privacy.md
@@ -1,0 +1,14 @@
+---
+hidden: false
+layout: session-speaker-template
+speakers: 
+  - Vikram Waradpande
+  - Sarthika Dhawan
+permalink: /sessions/you-ve-got-trust-issues-we-ve-got-solutions-differential-privacy/
+session_type: Talk
+session_title: "You've got trust issues, we've got solutions: Differential Privacy"
+photo_url: https://pretalx.com/media/avatars/AspireProfilePhoto_zheITSJ.jpeg
+twitter: null
+website: null
+---
+

--- a/bin/generate_sessions.py
+++ b/bin/generate_sessions.py
@@ -1,0 +1,138 @@
+"""
+Generate 2023 session md and tweet CSV from pretalx schedule
+Requires `TOKEN` environment variable (pretalx API token)
+"""
+from argparse import ArgumentParser
+import csv
+import json
+import os
+from pathlib import Path
+import random
+import re
+from urllib.parse import urljoin
+
+import requests
+
+BASE_PATH = Path(__file__).parent.parent 
+
+def api_get(path):
+    api_url = urljoin("https://pretalx.com/api/v2", path)
+    resp = requests.get(api_url, headers={"Authorization": f"Token {os.getenv('TOKEN')}"})
+    return resp.json()
+
+
+def get_talks(refetch=False):
+    selections_path = BASE_PATH / "talks.json"
+    def _relevant_session_type(talk):
+        if talk['submission_type'] == "Talk":
+            return True
+        return talk['submission_type']['en'] in ["Workshop", "Keynote"]
+
+    if selections_path.exists() and refetch is False:
+        return json.load(selections_path.open())
+    else:
+        resp = api_get("events/djangocon-europe-2023/talks/?limit=50")
+        submissions = {
+            result["code"]: result for result in resp["results"] if _relevant_session_type(result) 
+        }
+        with selections_path.open("w") as out:
+            json.dump(submissions, out)
+        return submissions
+
+
+def get_speakers(talk_codes, refetch=False):
+    speakers_path = BASE_PATH / "speakers.json"
+    if speakers_path.exists() and refetch is False:
+        return json.load(speakers_path.open())
+    else:
+        resp = api_get("events/djangocon-europe-2023/speakers/?limit=200")
+        speakers = {
+            result["code"]: result for result in resp["results"] if any(sub in talk_codes for sub in result['submissions'])
+        }
+        with speakers_path.open("w") as out:
+            json.dump(speakers, out)
+        return speakers
+
+
+def update_info(talk, speakers):
+    formatted = {
+        "title": talk["title"],
+        "slug": re.sub(r'\W+', '-', talk["title"]).strip('-').lower(),
+        "url": f"https://pretalx.com/djangocon-europe-2023/talk/{talk['code']}",
+        "type": talk["submission_type"] if isinstance(talk["submission_type"], str) else talk["submission_type"]["en"],
+        "state": talk["state"],
+        "speakers": [speaker["name"] for speaker in talk["speakers"]],
+        "slot": talk["slot"]
+    }
+    formatted["title"] = formatted["title"].replace("Keynote: ", "")
+    first_speaker = talk["speakers"][0]
+    formatted["photo_url"] = speakers[first_speaker["code"]]["avatar"]
+    return formatted
+
+
+def generate_session_md(session):
+    speakers = "\n".join([f"  - {speaker}" for speaker in session["speakers"]])
+    markdown = f"""---
+hidden: false
+layout: session-speaker-template
+speakers: 
+{speakers}
+permalink: /sessions/{session['slug']}/
+session_type: {session['type']}
+session_title: "{session['title']}"
+photo_url: {session['photo_url']}
+twitter: null
+website: null
+---
+
+"""
+    with open(BASE_PATH / "_sessions" / f"{session['slug']}.md", "w") as outfile:
+        outfile.write(markdown)
+
+
+def generate_tweet(talk):
+    emoji = {
+        "Talk": "🎙",
+        "Workshop": "🎙",
+        "Keynote": "⭐️",
+    }
+    content = f'''{emoji[talk['type']]} {talk['type'].upper()}: "{talk['title']}" by {" & ".join(talk['speakers'])}
+    
+Grab your ticket!
+https://2023.djangocon.eu/tickets
+'''
+    thumbnail_url = f"https://2023.djangocon.eu/sessions/{talk['slug']}"
+    return content, thumbnail_url
+
+def generate_tweet_csv(formatted_talks):
+    # randomly shuffle the talks before we generate the tweet content
+    random.shuffle(formatted_talks)
+    with open(BASE_PATH / "tweets.csv", "w") as outfile:
+        writer = csv.writer(outfile)
+        writer.writerow(["Content", "thumbnail_url"])
+        for talk in formatted_talks:
+            writer.writerow(generate_tweet(talk))
+
+
+def main(refetch=False):
+    talks = get_talks(refetch=refetch)
+    speakers = get_speakers(talks.keys(), refetch=refetch)    
+    formatted_talks = [update_info(talk, speakers) for talk in talks.values()]
+    
+    for talk in formatted_talks:
+        generate_session_md(talk)
+    
+    generate_tweet_csv(formatted_talks)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.description = """
+    Build session thumbnails and csv of tweet content from pretalx schedule
+    """
+    parser.add_argument(
+        "--refetch", "-r", action="store_true", 
+        help="Fetch schedule info from pretalx"
+    )
+    parsed = parser.parse_args()
+    main(parsed.refetch)


### PR DESCRIPTION
Now that the schedule's published, and we're only 6 weeks or so away from the conference, we need to start tweeting the talks.  This doesn't generate the thumbnails in quite the same way as the 2022 US site does, because I couldn't figure out all that we needed to do to get that to work.  Since we're not producing a schedule on the site (not atm anyway), we don't need it to be quite that complicated, so I've made a session template that just uses a single session md file, and a script that just fetches the things it needs from the pretalk API, and generates the session md files, and a randomly orderd CSV of tweet content.